### PR TITLE
fix: handle empty numeric input

### DIFF
--- a/src/components/BasicApp.tsx
+++ b/src/components/BasicApp.tsx
@@ -33,8 +33,12 @@ const BasicApp: React.FC = () => {
                                     <InputNumber
                                         addonBefore={name}
                                         placeholder="0"
-                                        onChange={(value) => {
-                                            dispatch(changeBasic({ [color]: value }));
+                                        onChange={(value: number | null) => {
+                                            dispatch(
+                                                changeBasic({
+                                                    [color]: value ?? 0,
+                                                }),
+                                            );
                                         }}
                                         style={{ '--color': color }}
                                     />
@@ -121,7 +125,11 @@ const BasicApp: React.FC = () => {
                                 max={12}
                                 min={1}
                                 onChange={(value: number | null) => {
-                                    dispatch(changeBasic({ fillTimes: value }));
+                                    dispatch(
+                                        changeBasic({
+                                            fillTimes: value ?? 0,
+                                        }),
+                                    );
                                 }}
                                 style={{ '--color': 'black' }}
                             />


### PR DESCRIPTION
## Summary
- prevent null values from causing NaN by normalizing InputNumber values

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f4e322acc83328420e27214cd8c46